### PR TITLE
 add postgresql-contrib in app dependencies 

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -71,7 +71,7 @@ ynh_app_setting_set "$app" port "$port"
 #=================================================
 
 ynh_install_app_dependencies build-essential curl ffmpeg \
-	libjpeg-dev libmagic-dev libpq-dev postgresql python3-dev python3-venv \
+	libjpeg-dev libmagic-dev libpq-dev postgresql postgresql-contrib python3-dev python3-venv \
 	redis-server libldap2-dev libsasl2-dev \
 	`# add arm support` \
 	zlib1g-dev libffi-dev libssl-dev


### PR DESCRIPTION
When installing Funk on my server, I had the following error message:

```bash
django.db.utils.OperationalError: could not open extension control file "/usr/share/postgresql/9.6/extension/unaccent.control": No such file or directory
```
The installation of `postgresql-contrib` solves this problem.