### PR TITLE
add dependencie postgresql-contrib

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -70,7 +70,7 @@ ynh_app_setting_set "$app" port "$port"
 #=================================================
 
 ynh_install_app_dependencies build-essential curl ffmpeg \
-	libjpeg-dev libmagic-dev libpq-dev postgresql python3-dev virtualenv \
+	libjpeg-dev libmagic-dev libpq-dev postgresql postgresql-contrib python3-dev virtualenv \
 	redis-server libldap2-dev libsasl2-dev \
 	`# add arm support` \
 	zlib1g-dev libffi-dev libssl-dev

--- a/scripts/restore
+++ b/scripts/restore
@@ -96,7 +96,7 @@ ynh_system_user_create "$app"
 #=================================================
 
 ynh_install_app_dependencies build-essential curl ffmpeg \
-	libjpeg-dev libmagic-dev libpq-dev postgresql python3-dev virtualenv \
+	libjpeg-dev libmagic-dev libpq-dev postgresql postgresql-contrib python3-dev virtualenv \
 	redis-server libldap2-dev libsasl2-dev \
 	`# add arm support` \
 	zlib1g-dev libffi-dev libssl-dev

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -143,7 +143,7 @@ ynh_system_user_create "$app"
 #=================================================
 
 ynh_install_app_dependencies build-essential curl ffmpeg \
-	libjpeg-dev libmagic-dev libpq-dev postgresql python3-dev virtualenv \
+	libjpeg-dev libmagic-dev libpq-dev postgresql postgresql-contrib python3-dev virtualenv \
 	redis-server libldap2-dev libsasl2-dev \
 	`# add arm support` \
 	zlib1g-dev libffi-dev libssl-dev


### PR DESCRIPTION
we are at least three to have had the same problem. When we install on a fresh install, we have : "django.db.utils.OperationalError: could not open extension control file "/usr/share/postgresql/9.6/extension/unaccent.control": No such file or directory"
See : [here](https://github.com/YunoHost-Apps/funkwhale_ynh/issues/36), [here ](https://forum.yunohost.org/t/funkwhale-failed-installation-logs/7017) ( and [issue 60](https://github.com/YunoHost-Apps/funkwhale_ynh/issues/60) it's the same user) and [here](https://forum.yunohost.org/t/funkwhale-install-fail/5754)