### PR TITLE
Update to 0.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A modern, convivial and free music server on YunoHost
 
 Installation requires a dedicated domain for now. I hope subpath installation will be possible in the future.
 
-**Shipped version:** 0.20.1 (this is an Alpha version!)
+**Shipped version:** 0.21
 
 ## Screenshots
 

--- a/conf/app-frontend.src
+++ b/conf/app-frontend.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://dev.funkwhale.audio/funkwhale/funkwhale/-/jobs/artifacts/0.20.1/download?job=build_front
-SOURCE_SUM=22d774590b943fa6d64f634a7175b1d100089fe33734ce9889d050063ff50ce7
+SOURCE_URL=https://dev.funkwhale.audio/funkwhale/funkwhale/-/jobs/artifacts/0.21/download?job=build_front
+SOURCE_SUM=d412b9bf0bb57d48332c6a6ab2f14c6d8e4dc792421ed4077f65550c58ecd754
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=false

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://dev.funkwhale.audio/funkwhale/funkwhale/-/archive/0.20.1/funkwhale-0.20.1.tar.gz
-SOURCE_SUM=4fe4c9069957060b3ab31cbc39f01d621aed01c39fc0177628fd96777fdffc7e
+SOURCE_URL=https://dev.funkwhale.audio/funkwhale/funkwhale/-/archive/0.21/funkwhale-0.21.tar.gz
+SOURCE_SUM=af4d5f9a339a47f5f8881e15dd3b60d4557d46569d1b1ec8b558b086ba101af8
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.bz2
 SOURCE_IN_SUBDIR=true

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,4 +1,3 @@
-
 location / {
         include __FINALPATH__/code/deploy/funkwhale_proxy.conf;
         # this is needed if you have file import via upload enabled
@@ -17,8 +16,14 @@ location /front/ {
 }
 
 location /front/embed.html {
-	more_set_headers X-Frame-Options "ALLOW";
+	add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; object-src 'none'; media-src 'self' data:";
+    add_header Referrer-Policy "strict-origin-when-cross-origin";
+	add_header X-Frame-Options "ALLOW";
 	alias __FINALPATH__/code/front/dist/embed.html;
+	expires 30d;
+    add_header Pragma public;
+    add_header Cache-Control "public, must-revalidate, proxy-revalidate";
+
 }
 
 location /federation/ {

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -13,16 +13,18 @@ location /front/ {
         more_set_headers Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; object-src 'none'; media-src 'self' data:";
         more_set_headers Referrer-Policy "strict-origin-when-cross-origin";
         more_set_headers X-Frame-Options "SAMEORIGIN";
+		more_set_headers Service-Worker-Allowed "/";
+
 }
 
 location /front/embed.html {
-	add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; object-src 'none'; media-src 'self' data:";
-    add_header Referrer-Policy "strict-origin-when-cross-origin";
-	add_header X-Frame-Options "ALLOW";
+	more_set_headers Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; object-src 'none'; media-src 'self' data:";
+    more_set_headers Referrer-Policy "strict-origin-when-cross-origin";
+	more_set_headers X-Frame-Options "ALLOW";
 	alias __FINALPATH__/code/front/dist/embed.html;
 	expires 30d;
-    add_header Pragma public;
-    add_header Cache-Control "public, must-revalidate, proxy-revalidate";
+    more_set_headers Pragma public;
+    more_set_headers Cache-Control "public, must-revalidate, proxy-revalidate";
 
 }
 

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,3 +1,4 @@
+
 location / {
         include __FINALPATH__/code/deploy/funkwhale_proxy.conf;
         # this is needed if you have file import via upload enabled
@@ -16,14 +17,8 @@ location /front/ {
 }
 
 location /front/embed.html {
-	add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; object-src 'none'; media-src 'self' data:";
-    add_header Referrer-Policy "strict-origin-when-cross-origin";
-	add_header X-Frame-Options "ALLOW";
+	more_set_headers X-Frame-Options "ALLOW";
 	alias __FINALPATH__/code/front/dist/embed.html;
-	expires 30d;
-    add_header Pragma public;
-    add_header Cache-Control "public, must-revalidate, proxy-revalidate";
-
 }
 
 location /federation/ {

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
 	"description": {
 		"en": "A modern, convivial and free music server"
 	},
-	"version": "0.21~ynh6",
+	"version": "0.21~ynh1",
 	"url": "https://funkwhale.audio",
 	"license": "AGPL-3.0-or-later",
 	"maintainer": {

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
 	"description": {
 		"en": "A modern, convivial and free music server"
 	},
-	"version": "0.20.1~ynh6",
+	"version": "0.21~ynh6",
 	"url": "https://funkwhale.audio",
 	"license": "AGPL-3.0-or-later",
 	"maintainer": {

--- a/manifest.json
+++ b/manifest.json
@@ -9,8 +9,8 @@
 	"url": "https://funkwhale.audio",
 	"license": "AGPL-3.0-or-later",
 	"maintainer": {
-		"name": "Jean-Baptiste Holcroft",
-		"email": "jean-baptiste@holcroft.fr"
+		"name": "Ciarán Ainsworth",
+		"email": "ciaranainsworth@posteo.net"
 	},
 	"requirements": {
         "yunohost": ">= 3.6"
@@ -35,7 +35,7 @@
 				"ask": {
 					"en": "Choose an admin user"
 				},
-				"example": "jibec"
+				"example": "sporiff"
 			},
 			{
 				"name": "is_public",
@@ -44,7 +44,7 @@
 					"en": "Is it a public application?"
 				},
 				"help": {
-					"en": "Allows non loggued users to access the user interface (mandatory for federation)"
+					"en": "Allows unauthenticated users to access the user interface (mandatory for federation)"
 				},
 				"default": true
 			}

--- a/sources/extra_files/app/api/requirements/base.txt
+++ b/sources/extra_files/app/api/requirements/base.txt
@@ -1,6 +1,7 @@
 # Bleeding edge Django
-django>=2.2.4,<2.3
-
+django>=3.0.5,<3.1; python_version > '3.5'
+django>=2.2.12,<3; python_version < '3.6'
+setuptools>=36
 # Configuration
 django-environ>=0.4,<0.5
 
@@ -9,71 +10,77 @@ Pillow>=6.2,<7
 
 # For user registration, either via email or social
 # Well-built with regular release cycles!
-django-allauth>=0.39,<0.40
+django-allauth>=0.41,<0.42
 
 
 # Python-PostgreSQL Database Adapter
 psycopg2-binary>=2.8,<=2.9
 
 # Time zones support
-pytz==2019.1
+pytz==2019.3
 
 # Redis support
-django-redis>=4.10,<4.11
-redis>=3.2,<3.3
+django-redis>=4.11,<4.12
+redis>=3.4,<3.5
 kombu>=4.5,<4.6
 
 celery>=4.3,<4.4
 
 
 # Your custom requirements go here
-django-cors-headers>=2.5.3,<2.6
+django-cors-headers>=3.2,<3.3
 musicbrainzngs==0.6
-djangorestframework>=3.10,<3.11
+djangorestframework>=3.11,<3.12
 djangorestframework-jwt>=1.11,<1.12
-pendulum>=2,<3
+arrow>=0.15.5,<0.16
 persisting-theory>=0.2,<0.3
-django-versatileimagefield>=1.10,<1.11
+django-versatileimagefield>=2.0,<2.1
 django-filter>=2.1,<2.2
 django-rest-auth>=0.9,<0.10
-ipython>=7,<8
-mutagen>=1.42,<1.43
+# XXX: remove when we drop support for python 3.5
+ipython>=7.10,<8; python_version > '3.5'
+ipython>=7,<7.10; python_version < '3.6'
+mutagen>=1.44,<1.45
 
 pymemoize==1.0.3
 
-django-dynamic-preferences>=1.7.1,<1.8
+django-dynamic-preferences>=1.8.1,<1.9
 raven>=6.10,<7
 python-magic==0.4.15
-# XXX: until https://github.com/django/channels/issues/1240 is fixed
-channels==2.1.6
-channels_redis>=2.3,<2.4
-daphne>=2.2,<2.3
-# uvicorn
-gunicorn
+channels>=2.4,<2.5
+# XXX: remove when we drop support for python 3.5
+channels_redis==2.2.1; python_version < '3.6'
+channels_redis>=2.3.2,<2.4; python_version > '3.5'
+uvicorn==0.8.6; python_version < '3.6'
+uvicorn>=0.11.3,<0.12; python_version > '3.5'
+gunicorn>=20.0.4,<20.1
 
-# YNH specific
-uvicorn==0.8.6
-service_identity
-# END YunoHost specific
-
-cryptography>=2,<3
+cryptography>=2.8,<3
 # requests-http-signature==0.0.3
 # clone until the branch is merged and released upstream
 git+https://github.com/EliotBerriot/requests-http-signature.git@signature-header-support
-django-cleanup==3.2.0
+django-cleanup>=4,<4.1
 requests>=2.22<2.23
 pyOpenSSL>=19<20
 
 # for LDAP authentication
-python-ldap==3.2.0
-django-auth-ldap==1.7.0
-pydub==0.23.1
+python-ldap>=3.2.0,<3.3
+django-auth-ldap>=2.1.0,<2.2
 
+pydub>=0.23.1,<0.24
 pyld==1.0.4
-aiohttp==3.5.4
+aiohttp>=3.6,<3.7
 autobahn>=19.3.3
 
 django-oauth-toolkit==1.2
-django-storages==1.7.1
+django-storages>=1.9.1,<1.10
 boto3<3
-unicode-slugify
+unicode-slugify==0.1.3
+django-cacheops==4.2
+
+click>=7,<8
+service_identity==18.1.0
+markdown>=3.2,<4
+bleach>=3,<4
+feedparser==6.0.0b3
+watchdog==0.10.2


### PR DESCRIPTION
Hi there,

Following the recent update to Funkwhale 0.21 I've been doing some testing on my local Yunohost dev server to upgrade this package. The install/upgrade works fine on my end.

This MR contains:

- New sources
- New requirements
- Updated NGINX configuration for service workers and SCP headers for embeds
- Updated manifest and README

Please let me know if anything else needs to be done.