### PR TITLE
correct requirements since vine 5.0.0 leads to an error

### DIFF
--- a/sources/extra_files/app/api/requirements/base.txt
+++ b/sources/extra_files/app/api/requirements/base.txt
@@ -77,6 +77,7 @@ django-storages>=1.9.1,<1.10
 boto3<3
 unicode-slugify==0.1.3
 django-cacheops==4.2
+vine==1.3.0
 
 click>=7,<8
 service_identity==18.1.0


### PR DESCRIPTION
On a fresh install on yunohost 4, the loader breaks.
It tries to install django and vine 5.0.0 (released in september)
Django imports vine.five
Vine.five cannot be imported in vine 5.0.0
Thus, one need to force a ancient version of vine