### PR TITLE
Uprade to 1.1 and fixes Twisted by retrograding it

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A modern, convivial and free music server on YunoHost
 
 Installation requires a dedicated domain or subdomain. Installing in a subpath is not supported by the upstream project due to dependency requirements.
 
-**Shipped version:** 1.0.1
+**Shipped version:** 1.1
 
 ## Screenshots
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -13,7 +13,7 @@ Un serveur de musique moderne, convivial et gratuit sur YunoHost
 
 L'installation nécessite un domaine ou un sous-domaine dédié. L'installation dans un chemin du domaine n'est pas prise en charge par le projet en amont en raison des exigences de dépendance.
 
-**Version incluse :** 1.0.1
+**Version incluse :** 1.1
 
 ## Captures d'écran
 

--- a/conf/app-frontend.src
+++ b/conf/app-frontend.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://dev.funkwhale.audio/funkwhale/funkwhale/builds/artifacts/1.1-rc2/download?job=build_front
-SOURCE_SUM=931e597e05832af41368feda177f16830e5a0f101027febfd5f8dbdd6ec84474
+SOURCE_URL=https://dev.funkwhale.audio/funkwhale/funkwhale/builds/artifacts/1.1/download?job=build_front
+SOURCE_SUM=cf985340ba0fe477fa5f9b8940102e016c0c75a9941dd8acabb8dc5f77cda000
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=false

--- a/conf/app-frontend.src
+++ b/conf/app-frontend.src
@@ -1,5 +1,5 @@
 SOURCE_URL=https://dev.funkwhale.audio/funkwhale/funkwhale/builds/artifacts/1.1-rc2/download?job=build_front
-SOURCE_SUM=dfb297678174d50d46277c11c98aaa47f867bbe1d9a9f549889f407297829885
+SOURCE_SUM=931e597e05832af41368feda177f16830e5a0f101027febfd5f8dbdd6ec84474
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=false

--- a/conf/app-frontend.src
+++ b/conf/app-frontend.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://dev.funkwhale.audio/funkwhale/funkwhale/builds/artifacts/1.0.1/download?job=build_front
-SOURCE_SUM=0b77367cb4e8d1b57af59282af90ac41e0915de85cf5337b02f16e6aa0bd0129
+SOURCE_URL=https://dev.funkwhale.audio/funkwhale/funkwhale/builds/artifacts/1.1-rc2/download?job=build_front
+SOURCE_SUM=dc438f49a583dc66b6452eb1d5acdf7efadf5ded3c5317ae3767b079eee68538
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=false

--- a/conf/app-frontend.src
+++ b/conf/app-frontend.src
@@ -1,5 +1,5 @@
 SOURCE_URL=https://dev.funkwhale.audio/funkwhale/funkwhale/builds/artifacts/1.1-rc2/download?job=build_front
-SOURCE_SUM=dc438f49a583dc66b6452eb1d5acdf7efadf5ded3c5317ae3767b079eee68538
+SOURCE_SUM=dfb297678174d50d46277c11c98aaa47f867bbe1d9a9f549889f407297829885
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=false

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://dev.funkwhale.audio/funkwhale/funkwhale/-/archive/1.0.1/funkwhale-1.01.tar.gz
-SOURCE_SUM=103e45a3c8ae2a1223cb83689ed0a8f35bc7dfa053725a9dfd211e0e0973141b
+SOURCE_URL=https://dev.funkwhale.audio/funkwhale/funkwhale/-/archive/1.1-rc2/funkwhale-1.1-rc2.tar.gz
+SOURCE_SUM=77986fdc1e6518e69653369ba23e846b270383c1b60d7e5be441f334141cd9fd
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.bz2
 SOURCE_IN_SUBDIR=true

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
 SOURCE_URL=https://dev.funkwhale.audio/funkwhale/funkwhale/-/archive/1.1-rc2/funkwhale-1.1-rc2.tar.gz
-SOURCE_SUM=77986fdc1e6518e69653369ba23e846b270383c1b60d7e5be441f334141cd9fd
+SOURCE_SUM=c96f56d0264d179a6a3506c092d2fbefe43214da229f19ae6842845be2e8b9f1
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.bz2
 SOURCE_IN_SUBDIR=true

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://dev.funkwhale.audio/funkwhale/funkwhale/-/archive/1.1-rc2/funkwhale-1.1-rc2.tar.gz
-SOURCE_SUM=c96f56d0264d179a6a3506c092d2fbefe43214da229f19ae6842845be2e8b9f1
+SOURCE_URL=https://dev.funkwhale.audio/funkwhale/funkwhale/-/archive/1.1/funkwhale-1.1.tar.gz
+SOURCE_SUM=924a31ba385c9c52204d78aa89a00b5f53240bf91a13b2c08945fde8f770d345
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.bz2
 SOURCE_IN_SUBDIR=true

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,7 @@
         "email": "jean-baptiste@holcroft.fr"
     }],
     "requirements": {
-        "yunohost": ">= 4.1.7.3"
+        "yunohost": ">= 4.0.0"
     },
     "multi_instance": true,
     "services": [

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Modern, convivial and free music server",
         "fr": "Serveur de musique moderne, convivial et gratuit"
     },
-    "version": "1.0.1~ynh1",
+    "version": "1.1-rc2~ynh1",
     "url": "https://funkwhale.audio",
     "license": "AGPL-3.0-or-later",
     "maintainer": {

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Modern, convivial and free music server",
         "fr": "Serveur de musique moderne, convivial et gratuit"
     },
-    "version": "1.1-rc2~ynh1",
+    "version": "1.1~ynh1",
     "url": "https://funkwhale.audio",
     "license": "AGPL-3.0-or-later",
     "maintainer": {

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,7 @@
         "email": "jean-baptiste@holcroft.fr"
     }],
     "requirements": {
-        "yunohost": ">= 4.0.0"
+        "yunohost": ">= 4.1.7.3"
     },
     "multi_instance": true,
     "services": [

--- a/sources/extra_files/app/api/requirements/base.txt
+++ b/sources/extra_files/app/api/requirements/base.txt
@@ -34,6 +34,8 @@ django-rest-auth~=0.9
 ipython~=7.10
 mutagen~=1.45
 
+Twisted==20.3.0 #there is a bug with higher versions of twisted. I assume it’s temporary.
+
 pymemoize~=1.0
 
 django-dynamic-preferences~=1.10

--- a/sources/extra_files/app/api/requirements/base.txt
+++ b/sources/extra_files/app/api/requirements/base.txt
@@ -1,76 +1,77 @@
 django~=3.0.8
 setuptools>=49
 # Configuration
-django-environ~=0.4
+django-environ~=0.4.0
 
 # Images
-Pillow~=7.0
+Pillow~=7.0.0
 
-django-allauth~=0.42
+django-allauth~=0.42.0
 
-psycopg2-binary~=2.8
+psycopg2-binary~=2.8.0
 
 # Time zones support
 pytz==2020.1
 
 # Redis support
-django-redis~=4.12
-redis~=3.5
-kombu~=4.6
+django-redis~=4.12.0
+redis~=3.5.0
+kombu~=4.6.0
 
-celery~=4.4
+celery~=4.4.0
 
 
 # Your custom requirements go here
-django-cors-headers~=3.4
+django-cors-headers~=3.4.0
 musicbrainzngs~=0.7.1
-djangorestframework~=3.11
-djangorestframework-jwt~=1.11
+djangorestframework~=3.11.0
+djangorestframework-jwt~=1.11.0
 arrow~=0.15.5
-persisting-theory~=0.2
-django-versatileimagefield~=2.0
-django-filter~=2.3
-django-rest-auth~=0.9
-ipython~=7.10
-mutagen~=1.45
+persisting-theory~=0.2.0
+django-versatileimagefield~=2.0.0
+django-filter~=2.3.0
+django-rest-auth~=0.9.0
+ipython~=7.10.0
+mutagen~=1.45.0
 
-Twisted==20.3.0 #there is a bug with higher versions of twisted. I assume it’s temporary.
-
-pymemoize~=1.0
+pymemoize~=1.0.0
 
 django-dynamic-preferences~=1.10
-raven~=6.10
-python-magic~=0.4
-channels~=2.4
-channels_redis~=3.0
-uvicorn[standard]~=0.12
-gunicorn~=20.0
+raven~=6.10.0
+python-magic~=0.4.0
+channels~=2.4.0
+channels_redis~=3.0.0
+uvicorn[standard]~=0.12.0
+gunicorn~=20.0.0
 
-cryptography~=2.9
+cryptography~=2.9.0
 # requests-http-signature==0.0.3
 # clone until the branch is merged and released upstream
-git+https://github.com/EliotBerriot/requests-http-signature.git@signature-header-support
-django-cleanup~=5.0
-requests~=2.24
-pyOpenSSL~=19.1
+git+https://github.com/agateblue/requests-http-signature.git@signature-header-support
+django-cleanup~=5.0.0
+requests~=2.24.0
+pyOpenSSL~=19.1.0
 
 # for LDAP authentication
-python-ldap~=3.3
-django-auth-ldap~=2.2
+python-ldap~=3.3.0
+django-auth-ldap~=2.2.0
 
-pydub~=0.24
-pyld~=1.0
-aiohttp~=3.6
+pydub~=0.24.0
+pyld~=1.0.0
+aiohttp~=3.6.0
 
-django-oauth-toolkit~=1.3
-django-storages~=1.9
-boto3~=1.14
-unicode-slugify~=0.1
-django-cacheops~=5.0
+django-oauth-toolkit~=1.3.0
+django-storages~=1.9.0
+boto3~=1.14.0
+unicode-slugify~=0.1.0
+django-cacheops~=5.0.0
 
-click~=7.1
-service_identity~=18.1
-markdown~=3.2
-bleach~=3.1
-feedparser==6.0.0b3
-watchdog~=0.10
+click~=7.1.0
+service_identity~=18.1.0
+markdown~=3.2.0
+bleach~=3.1.0
+feedparser~=6.0.0
+watchdog~=1.0.2
+
+## Pin third party dependency to avoid issue with latest version
+twisted==20.3.0


### PR DESCRIPTION
- Upgrade to 1.1

- Fixes Twisted by retrograding it (cf. https://forum.yunohost.org/t/funkwhale-server-crash/14774/2)

Tested install, but not upgrade.