### PR TITLE
Clarify custom paths needed to import collections of music files in Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,11 @@ Installation requires a dedicated domain or subdomain. Installing in a subpath i
 ## Admin
 
 The admin uses the login you provided at installation. The password is the same you use for YunoHost.
-
 The admin interface is accessible at the address: `your.domain.fr/api/admin`
+
+To add a collection of music files to a library in your Yunohost installation of Funkwhale, create a symlink to your collection titled "import" in /var/www/funkwhale
+'''ln -s /your/music/collection /var/www/funkwhale/import
+The files can be uploaded from the *uploading* tab in a music library under the heading **Import music from your server**.
 
 # State of this package
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,11 @@ The admin uses the login you provided at installation. The password is the same 
 The admin interface is accessible at the address: `your.domain.fr/api/admin`
 
 To add a collection of music files to a library in your Yunohost installation of Funkwhale, create a symlink to your collection titled "import" in /var/www/funkwhale
-'''ln -s /your/music/collection /var/www/funkwhale/import
-The files can be uploaded from the *uploading* tab in a music library under the heading **Import music from your server**.
+```console
+foo@bar:~$sudo ln -s /your/music/collection /var/www/funkwhale/import
+```
+The files can then be added to your library from the *uploading* tab in a music library under the heading **Import music from your server**.
+
 
 # State of this package
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Installation requires a dedicated domain or subdomain. Installing in a subpath i
 The admin uses the login you provided at installation. The password is the same you use for YunoHost.
 The admin interface is accessible at the address: `your.domain.fr/api/admin`
 
-To add a collection of music files to a library in your Yunohost installation of Funkwhale, create a symlink to your collection titled "import" in /var/www/funkwhale
+To add a collection of music files to a library in your YunoHost installation of Funkwhale, create a symlink to your collection titled "import" in `/var/www/funkwhale`
 ```console
 foo@bar:~$sudo ln -s /your/music/collection /var/www/funkwhale/import
 ```


### PR DESCRIPTION
Yunohost installations of Funkwhale use a different path for importing large quantities of music files "in place" than the paths indicated in the Funkwhale documentation. Clarify for admin users the steps necessary to add large collections of files to a Yunohost Funkwhale installation.

Addresses #132