### PR TITLE
Fix datadir issue

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -128,7 +128,6 @@ ynh_add_nginx_config
 #=================================================
 ynh_script_progression --message="Creating a data directory..."
 
-# datadir=/home/yunohost.app/$app
 ynh_app_setting_set --app=$app --key=datadir --value=$datadir
 
 mkdir -p $datadir

--- a/scripts/install
+++ b/scripts/install
@@ -128,7 +128,7 @@ ynh_add_nginx_config
 #=================================================
 ynh_script_progression --message="Creating a data directory..."
 
-datadir=/home/yunohost.app/$app
+# datadir=/home/yunohost.app/$app
 ynh_app_setting_set --app=$app --key=datadir --value=$datadir
 
 mkdir -p $datadir


### PR DESCRIPTION
## Problem

- `__DATADIR__` was incorrectly being redeclared during install, causing  #152 

## Solution

- This PR removes the re-declaration that caused the bug
- `datadir` is already declared correctly at line 43 in the `install` file 
- This PR fixes #152 

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)
- [ ] Tested on a fresh YUNO install with no other apps installed

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
