### PR TITLE
Funkwhale 1.2.8 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 
 Funkwhale is a community-driven project that lets you listen and share music and audio within a decentralized, open network. 
 
-**Shipped version:** 1.2.7~ynh1
+**Shipped version:** 1.2.8~ynh1
 
 **Demo:** https://demo.funkwhale.audio
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Funkwhale is a community-driven project that lets you listen and share music and
 
 **Shipped version:** 1.2.8~ynh1
 
+
 **Demo:** https://demo.funkwhale.audio
 
 ## Screenshots

--- a/README_fr.md
+++ b/README_fr.md
@@ -17,7 +17,8 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 
 Funkwhale est un projet communautaire qui vous permet d'écouter et de partager de la musique et de l'audio au sein d'un réseau ouvert et décentralisé. 
 
-**Version incluse :** 1.2.8~ynh1
+**Version incluse :** 1.2.8~ynh1
+
 
 **Démo :** https://demo.funkwhale.audio
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -17,7 +17,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 
 Funkwhale est un projet communautaire qui vous permet d'écouter et de partager de la musique et de l'audio au sein d'un réseau ouvert et décentralisé. 
 
-**Version incluse :** 1.2.7~ynh1
+**Version incluse :** 1.2.8~ynh1
 
 **Démo :** https://demo.funkwhale.audio
 

--- a/conf/api.src
+++ b/conf/api.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://dev.funkwhale.audio/funkwhale/funkwhale/-/jobs/artifacts/1.2.7/download?job=build_api
-SOURCE_SUM=9bf003b3427b236df2fa322e9af7e72b4982934ea0b7add4134735739fa9966d
+SOURCE_URL=https://dev.funkwhale.audio/funkwhale/funkwhale/-/jobs/artifacts/1.2.8/download?job=build_api
+SOURCE_SUM=70b2da23960531082ecd0db259fefe25cbbb4c7e88f5578739ce0bccc2b8cf69
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=true

--- a/conf/front.src
+++ b/conf/front.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://dev.funkwhale.audio/funkwhale/funkwhale/builds/artifacts/1.2.7/download?job=build_front
-SOURCE_SUM=5a178160939d4189aacb0d1b3acd743df233f3d34d73e6bedeb573b34f5baec7
+SOURCE_URL=https://dev.funkwhale.audio/funkwhale/funkwhale/builds/artifacts/1.2.8/download?job=build_front
+SOURCE_SUM=bd110dee284f5332aa00a3be53a61a65dbd8a20c10d4229287dec9f0bfd8c2f7
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=true

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Modern, convivial and free music server",
         "fr": "Serveur de musique moderne, convivial et gratuit"
     },
-    "version": "1.2.7~ynh1",
+    "version": "1.2.8~ynh1",
     "url": "https://funkwhale.audio",
     "upstream": {
         "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Problem

- A new bugfix release came out that fixes issues with pyopenssl and cryptography

## Solution

- Bump the version from 1.2.7 to 1.2.8

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
