### PR TITLE
[autopatch] TEST BEFORE MERGE ynh_setup_source --full_replace=1

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -61,8 +61,8 @@ ram.runtime = "50M"
         format = "zip"
 
         autoupdate.strategy = "latest_gitlab_release"
-        autoupdate.asset.api = "api.*"
-        autoupdate.asset.front = "front.*"
+       # autoupdate.asset.api = "api.*"
+       # autoupdate.asset.front = "front.*"
 
     [resources.ports]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -60,10 +60,6 @@ ram.runtime = "50M"
         extract   = true
         format = "zip"
 
-        autoupdate.strategy = "latest_gitlab_release"
-       # autoupdate.asset.api = "api.*"
-       # autoupdate.asset.front = "front.*"
-
     [resources.ports]
 
     [resources.system_user]

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -39,8 +39,8 @@ then
 	ynh_secure_remove --file="$install_dir/front"
 
 	# Download, check integrity, uncompress and patch the source from app.src
-	ynh_setup_source --dest_dir="$install_dir/api" --source_id="api"
-	ynh_setup_source --dest_dir="$install_dir/front" --source_id="front"
+	ynh_setup_source --dest_dir="$install_dir/api" --source_id="api" --full_replace=1
+	ynh_setup_source --dest_dir="$install_dir/front" --source_id="front" --full_replace=1
 fi
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -33,10 +33,6 @@ ynh_systemd_action --action="stop" --service_name="${app}-worker" --log_path="sy
 if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
 	ynh_script_progression --message="Upgrading source files..." --weight=1
-	
-	# Remove the old files
-	ynh_secure_remove --file="$install_dir/api"
-	ynh_secure_remove --file="$install_dir/front"
 
 	# Download, check integrity, uncompress and patch the source from app.src
 	ynh_setup_source --dest_dir="$install_dir/api" --source_id="api" --full_replace=1


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** patch to potentially fix a bug in the upgrade script.

`ynh_setup_source` doesn't overwrite the destination directory, but rather extracts the source in the existing directory.

This might lead to weird cases where legacy source files aren't deleted.

The command has an argument `--full_replace=1` that fixes this behaviour.

BE CAREFUL because this change might lead to data losses! You should check that all the patches calls to `ynh_setup_source`
_do exactly what you expect to do_ and don't **delete user data**.

If you want exclude some files from being overwritten/deleted, use the `--keep` argument, just like that:

```bash
ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="config/config.yaml"
```